### PR TITLE
Fix a shallow copy bug with min/max date

### DIFF
--- a/ps-input-time.js
+++ b/ps-input-time.js
@@ -285,8 +285,8 @@
                   checkMinMaxValid();
                   ngModel.$setValidity('time', true);
 
-                  if (minDate !== null && value < minDate) value = minDate;
-                  if (maxDate !== null && value > maxDate) value = maxDate;
+                  if (minDate !== null && value < minDate) value = new Date(minDate);
+                  if (maxDate !== null && value > maxDate) value = new Date(maxDate);
 
                   return value;
 


### PR DESCRIPTION
Max date sometimes starts getting updated because it is shallow copied to value so changing value changes min/maxdate.
